### PR TITLE
Allow plotting multiple balls

### DIFF
--- a/prologue.py
+++ b/prologue.py
@@ -75,12 +75,18 @@ def get_ball_image():
     return Image(im)
 
 def plot_ball(y, x):
+    max_balls = 100
     try:
+        if len(__app_response__["balls"]) == max_balls:
+            return
         x = int(x)
         y = int(y)
 
         __app_response__["balls"].append({"y": y, "x": x})
 
         print(f"Ball has been plotted to y={y}, x={x}")
+        if len(__app_response__["balls"]) == max_balls:
+            print("Max number of balls (max_balls) reached!")
+            return
     except ValueError:
         print("plot_ball(x, y) expects integers >:/")

--- a/prologue.py
+++ b/prologue.py
@@ -86,7 +86,7 @@ def plot_ball(y, x):
 
         print(f"Ball has been plotted to y={y}, x={x}")
         if len(__app_response__["balls"]) == max_balls:
-            print("Max number of balls (max_balls) reached!")
+            print(f"Max number of balls ({max_balls}) reached!")
             return
     except ValueError:
         print("plot_ball(x, y) expects integers >:/")

--- a/prologue.py
+++ b/prologue.py
@@ -62,7 +62,7 @@ class Image(object):
 
 # JSON response dictionary
 __app_response__ = {
-    "ball": {"y": 0, "x": 0},
+    "balls": [],
     "stdout": ""
 }
 
@@ -79,7 +79,7 @@ def plot_ball(y, x):
         x = int(x)
         y = int(y)
 
-        __app_response__["ball"] = {"y": y, "x": x}
+        __app_response__["balls"].append({"y": y, "x": x})
 
         print(f"Ball has been plotted to y={y}, x={x}")
     except ValueError:

--- a/public/recruiting.css
+++ b/public/recruiting.css
@@ -43,7 +43,6 @@ figure {
 
 figure .cursor {
   position: absolute;
-  opacity: 0;
 }
 
 section {

--- a/public/recruiting.js
+++ b/public/recruiting.js
@@ -26,9 +26,9 @@ var requestTimeout = (evt) => {
 };
 
 var clearBalls = () => {
-    var cursors = document.getElementsByClassName("cursor");
-    while(cursors[0]) {
-        cursors[0].parentNode.removeChild(cursors[0]);
+    var cursors = document.querySelectorAll(".cursor");
+    for (cursor of cursors) {
+        cursor.parentNode.removeChild(cursor);
     }
 };
 

--- a/public/recruiting.js
+++ b/public/recruiting.js
@@ -3,9 +3,12 @@ var resultsLoad = (evt) => {
 
     if (status == 200) {
         data = JSON.parse(evt.target.responseText);
+        clearBalls();
 
         document.querySelector(".code-output").innerText = data.stdout
-        plotBall(data.ball);
+        for (ball of data.balls) {
+            plotBall(ball);
+        }
     } else {
         alert(`Server returned status ${status}! See console for details.`);
         console.log(evt.target);
@@ -22,10 +25,20 @@ var requestTimeout = (evt) => {
     console.log(evt.target);
 };
 
+var clearBalls = () => {
+    var cursors = document.getElementsByClassName("cursor");
+    while(cursors[0]) {
+        cursors[0].parentNode.removeChild(cursors[0]);
+    }
+};
+
 var plotBall = (ball) => {
     var graphic = document.querySelector(".graphic");
-    var cursor = document.querySelector(".cursor");
-    cursor.style.opacity = "1";
+    var plot = document.querySelector(".plot");
+    var cursor = document.createElement("img");
+    cursor.setAttribute("class", "cursor");
+    cursor.src = "cursor.png"
+    plot.insertBefore(cursor, graphic);
 
     if (ball.y < 0) {
         alert('Y-Koordinate darf nicht kleiner als 0 sein >:/');

--- a/templates/index.html.ep
+++ b/templates/index.html.ep
@@ -79,7 +79,6 @@
 
 <section class="ide">
   <figure class="plot">
-    <img class="cursor" src="cursor.png">
     <img class="graphic" src="test.png">
   </figure>
 


### PR DESCRIPTION
This PR changes the `plot_ball` function to plot a new ball each time instead of overwriting the previous value.
The html/js side has been changed to dynamically create/remove the cursor elements to match the number of balls to be plotted.
There is a limit of 100 balls to prevent the browser from hanging.